### PR TITLE
Start dashboard cleanup

### DIFF
--- a/jobs/default.rb
+++ b/jobs/default.rb
@@ -8,7 +8,7 @@ SCHEDULER.every '5m', :first_in => 0 do |job|
 
     dashboard = dashboard.match(/^dashboards\/(.*)\.erb$/)[1]
     dashboards << {
-      label: dashboard,
+      label: "<a href='#{dashboard}'>#{dashboard}</a>",
       value: "<a href='#{dashboard}'>Go</a>"
     }
   end


### PR DESCRIPTION
- Make the dashboard name clickable (I try to click it every time)
- Don't include the start dashboard on the list, since you are looking at it.
