### PR TITLE
Update rack-protection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,10 @@ gem 'fitgem'
 gem 'haml'
 gem 'httparty'
 
+# Pin sinatra to a version that supports ruby 2.1.5
+gem 'rack-protection', '~> 1.5.5'
+gem 'sinatra', '~> 1.4.8'
+
 ## Remove this if you don't need a twitter widget.
 gem 'twitter', '>= 5.9.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     oauth (0.5.1)
     public_suffix (2.0.4)
     rack (1.5.5)
-    rack-protection (1.5.3)
+    rack-protection (1.5.5)
       rack
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
@@ -118,6 +118,8 @@ DEPENDENCIES
   haml
   httparty
   json
+  rack-protection (~> 1.5.5)
+  sinatra (~> 1.4.8)
   smashing
   twitter (>= 5.9.0)
   xml-simple (~> 1.1.4)


### PR DESCRIPTION
Clears security warning.

Related: https://nvd.nist.gov/vuln/detail/CVE-2018-1000119