### PR TITLE
Update Sprockets to address CVE-2018-3760

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,11 @@ gem 'fitgem'
 gem 'haml'
 gem 'httparty'
 
-# Pin sinatra to a version that supports ruby 2.1.5
+# Pin gems to version that supports ruby 2.1.5
 gem 'rack-protection', '~> 1.5.5'
 gem 'sinatra', '~> 1.4.8'
+gem 'http', '~> 2.1.0'
+gem 'sprockets', '~> 2.12.5'
 
 ## Remove this if you don't need a twitter widget.
 gem 'twitter', '>= 5.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
     json (2.0.2)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
-    multi_json (1.12.2)
+    multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     naught (1.1.0)
@@ -77,10 +77,10 @@ GEM
       sass (~> 3.2.12)
       sinatra (~> 1.4.4)
       sinatra-contrib (~> 1.4.2)
-      sprockets (~> 2.10.1)
+      sprockets (~> 2.12.5)
       thin (~> 1.6.1)
       thor (~> 0.19)
-    sprockets (2.10.2)
+    sprockets (2.12.5)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
@@ -116,11 +116,13 @@ DEPENDENCIES
   fitgem
   foursquare2
   haml
+  http (~> 2.1.0)
   httparty
   json
   rack-protection (~> 1.5.5)
   sinatra (~> 1.4.8)
   smashing
+  sprockets (~> 2.12.5)
   twitter (>= 5.9.0)
   xml-simple (~> 1.1.4)
 


### PR DESCRIPTION
- Update `sprockets` to 2.12.5
- Pin `http` to a version that supports Ruby 2.1.5

Related: https://groups.google.com/forum/#!topic/ruby-security-ann/2S9Pwz2i16k